### PR TITLE
Change getCurrentMessage to public

### DIFF
--- a/Behat/MailCatcherContext.php
+++ b/Behat/MailCatcherContext.php
@@ -138,7 +138,7 @@ class MailCatcherContext implements Context
     /**
      * @return Message|null
      */
-    private function getCurrentMessage()
+    public function getCurrentMessage()
     {
         if (null === $this->currentMessage) {
             throw new \RuntimeException('No message selected');


### PR DESCRIPTION
We have developed a context to click on link in mail but to do this we need to have access to the current message of the context but *getCurrentMessage* is private.
