### PR TITLE
Curl options can now be configured

### DIFF
--- a/Behat/MailCatcherExtension/Extension.php
+++ b/Behat/MailCatcherExtension/Extension.php
@@ -32,7 +32,13 @@ class Extension implements ExtensionInterface
 
         $this->loadContextInitializer($container);
 
+        foreach ($config['curl_options'] as $key => $value) {
+            $config['curl_options'][constant($key)] = $value;
+            unset($config['curl_options'][$key]);
+        }
+
         $container->setParameter('behat.mailcatcher.client.url', $config['url']);
+        $container->setParameter('behat.mailcatcher.client.curl_options', $config['curl_options']);
         $container->setParameter('behat.mailcatcher.purge_before_scenario', $config['purge_before_scenario']);
     }
 
@@ -58,6 +64,10 @@ class Extension implements ExtensionInterface
             ->children()
                 ->booleanNode('purge_before_scenario')->defaultTrue()->end()
                 ->scalarNode('url')->defaultValue('http://localhost:1080')->end()
+                ->arrayNode('curl_options')
+                    ->prototype('scalar')
+                    ->end()
+                ->end()
             ->end()
         ;
     }

--- a/Behat/MailCatcherExtension/services/core.xml
+++ b/Behat/MailCatcherExtension/services/core.xml
@@ -9,9 +9,9 @@
     </parameters>
 
     <services>
-
         <service id="behat.mailcatcher.client" class="%behat.mailcatcher.client.class%">
             <argument>%behat.mailcatcher.client.url%</argument>
+            <argument>%behat.mailcatcher.client.curl_options%</argument>
         </service>
 
         <service id="behat.mailcatcher.context.initializer" class="%behat.mailcatcher.context.initializer.class%">
@@ -22,6 +22,5 @@
         </service>
 
         <service id="mailcatcher" alias="behat.mailcatcher.client" />
-
     </services>
 </container>


### PR DESCRIPTION
This PR will make the curl options configurable. I needed this because my colleague's mailcatcher was never responding within 3 seconds (he should fix that too).

curl seems to work with integer keys and I didn't want the configuration to look like this:

---
    155: 2000
    1413: foo
---

So with my PR your fictional extension config might look like this:

---
        Alex\MailCatcher\Behat\MailCatcherExtension\Extension:
            url: http://mailcatcher.dev:1080
            purge_before_scenario: true
            curl_options:
              CURLOPT_TIMEOUT_MS: 5000
---

Where CURLOPT_TIMEOUT_MS is a literal name of a constant that can be used by curl.