### PR TITLE
Bumped Symfony requirement to allow 3.X

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "target-dir": "Alex/MailCatcher",
     "require": {
         "php":                     ">=5.3.3",
-        "symfony/dom-crawler":     "~2.3"
+        "symfony/dom-crawler":     "~2.3|~3.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
Hello @alexandresalome !

Here is a PR that allows projects under Symfony 3.0 to use this extension.