### PR TITLE
Add Mailhog-Support

### DIFF
--- a/Behat/MailCatcherExtension/Extension.php
+++ b/Behat/MailCatcherExtension/Extension.php
@@ -44,7 +44,12 @@ class Extension implements ExtensionInterface
      */
     private function loadMailhog(ContainerBuilder $container)
     {
-        $container->setDefinition(self::MAILCATCHER_ID, new Definition('Alex\MailCatcher\MailhogClient'));
+        $container->setDefinition(self::MAILCATCHER_ID, new Definition(
+            'Alex\MailCatcher\MailhogClient',
+            array(
+                '%behat.mailcatcher.client.url%'
+            )
+        ));
     }
 
     /**

--- a/Behat/MailCatcherExtension/Extension.php
+++ b/Behat/MailCatcherExtension/Extension.php
@@ -30,10 +30,21 @@ class Extension implements ExtensionInterface
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/services'));
         $loader->load('core.xml');
 
+        if ($config['mailhog'])
+            $this->loadMailhog($container);
+
         $this->loadContextInitializer($container);
 
         $container->setParameter('behat.mailcatcher.client.url', $config['url']);
         $container->setParameter('behat.mailcatcher.purge_before_scenario', $config['purge_before_scenario']);
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    private function loadMailhog(ContainerBuilder $container)
+    {
+        $container->setDefinition(self::MAILCATCHER_ID, new Definition('Alex\MailCatcher\MailhogClient'));
     }
 
     /**
@@ -57,6 +68,7 @@ class Extension implements ExtensionInterface
         $builder
             ->children()
                 ->booleanNode('purge_before_scenario')->defaultTrue()->end()
+                ->booleanNode('mailhog')->defaultFalse()->end()
                 ->scalarNode('url')->defaultValue('http://localhost:1080')->end()
             ->end()
         ;

--- a/Behat/MailCatcherExtension/services/core.xml
+++ b/Behat/MailCatcherExtension/services/core.xml
@@ -21,7 +21,9 @@
             <tag name="behat.context.initializer" />
         </service>
 
-        <service id="mailcatcher" alias="behat.mailcatcher.client" />
+        <service id="mailcatcher" alias="behat.mailcatcher.client">
+            <argument>%behat.mailcatcher.client.url%</argument>
+        </service>
 
     </services>
 </container>

--- a/MailhogAttachment.php
+++ b/MailhogAttachment.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Alex\MailCatcher;
+
+/**
+ * Attachment of a message.
+ *
+ * @author Alexandre Salomé <alexandre.salome@gmail.com>
+ * @author Christoph Gross <gross@gross-it.com>
+ */
+class MailhogAttachment
+{
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * @var string
+     */
+    protected $filename;
+
+    /**
+     * @var int
+     */
+    protected $size;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * Content of attachment.
+     *
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * Attachment CID
+     *
+     * @var string
+     */
+    protected $cid;
+
+    /**
+     * Encoding of content
+     *
+     * @var string
+     */
+    protected $encoding = false;
+
+    /**
+     * Raw content
+     *
+     * @var string
+     */
+    protected $rawContent;
+
+    /**
+     * Constructor.
+     *
+     * @param Client $client
+     * @param array  $data
+     */
+    public function __construct(Client $client, array $data = array())
+    {
+        $this->client = $client;
+        $this->loadFromArray($data);
+    }
+
+    /**
+     * Loads data into the Attachment from an array.
+     *
+     * @param array $array
+     *
+     * @return Attachment
+     */
+    public function loadFromArray(array $array)
+    {
+        $headers = $array['Headers'];
+        $contentDisposition = $headers['Content-Disposition'][0];
+        $contentType = $headers['Content-Type'][0];
+
+        if (preg_match('/filename=(.*)/', $contentDisposition, $match) === 1) {
+            $this->filename = $match[1];
+        }
+
+        # Mailcatcher seems to count this differently => see getSize()
+//        if (isset($array['Size'])) {
+//            $this->size = $array['Size'];
+//        }
+
+        if (preg_match('/(.*);/', $contentType, $match) === 1) {
+            $this->type = $match[1];
+        }
+
+        if (isset($array['id'])) {
+            $this->cid = $array['id'];
+        }
+
+        if (isset($headers['Content-Transfer-Encoding']) && count($headers['Content-Transfer-Encoding']) > 0) {
+            $this->encoding = $headers['Content-Transfer-Encoding'][0];
+        }
+
+        if (isset($array['Body'])) {
+            $this->rawContent = $array['Body'];
+        }
+        return $this;
+    }
+
+    /**
+     * Returns filename.
+     *
+     * @return string
+     */
+    public function getFilename()
+    {
+        return $this->filename;
+    }
+
+    /**
+     * Returns size.
+     *
+     * @return int
+     */
+    public function getSize()
+    {
+        return strlen($this->getContent());
+    }
+
+    /**
+     * Returns type.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Returns CID.
+     *
+     * @return string
+     */
+    public function getCid()
+    {
+        return $this->cid;
+    }
+
+    /**
+     * Returns content, decoded if possible
+     *
+     * @return string
+     */
+    public function getContent()
+    {
+        if (! $this->encoding) {
+            $this->content = $this->rawContent;
+        }
+        else if ($this->encoding === 'base64') {
+            $this->content = base64_decode($this->rawContent);
+        } else {
+            throw new \RuntimeException('Unsupported encoding: ' + $this->encoding);
+        }
+        return $this->content;
+    }
+}

--- a/MailhogClient.php
+++ b/MailhogClient.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Alex\MailCatcher;
+
+/**
+ * Client to manipulate a Mailhog server.
+ *
+ * @author Alexandre Salomé <alexandre.salome@gmail.com>
+ * @author Christoph Gross <gross@gross-it.com>
+ */
+class MailhogClient extends Client
+{
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @var array
+     */
+    protected $messages = array();
+
+    /**
+     * Creates a new client.
+     *
+     * @param string $url url of the server
+     */
+    public function __construct($url = 'http://localhost:8025')
+    {
+        $this->url = $url;
+    }
+
+    /**
+     * Deletes all messages on server.
+     *
+     * @return Client
+     */
+    public function purge()
+    {
+        $this->request('DELETE');
+        $this->messages = array();
+
+        return $this;
+    }
+
+    /**
+     * @return string URL of server used by the client
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * Returns the number of messages on the server.
+     *
+     * @return int
+     */
+    public function getMessageCount()
+    {
+        return count($this->request('GET'));
+    }
+
+    /**
+     * Searches for one messages on the server.
+     *
+     * See method `Message::match` method for more informations on criterias.
+     *
+     * @param array $criterias
+     *
+     * @return Message|null
+     */
+    public function searchOne(array $criterias = array())
+    {
+        $results = $this->search($criterias, 1);
+
+        if (count($results) !== 1) {
+            return null;
+        }
+
+        return $results[0];
+    }
+
+    /**
+     * Searches for messages on the server.
+     *
+     * See method `Method::match` for more informations on criterias.
+     *
+     * @param array $criterias an array of criterias
+     * @param int   $limit     maximum number of elements to fetch. Null means no limit
+     *
+     * @return array a list of messages
+     */
+    public function search(array $criterias = array(), $limit = null)
+    {
+        $messages = array();
+
+        foreach ($this->request('GET') as $message) {
+            if (isset($this->messages[$message['ID']])) {
+                $messages[] = $this->messages[$message['ID']];
+            } else {
+                $messages[] = $this->messages[$message['ID']] = new MailhogMessage($this, $message);
+            }
+        }
+
+        $result = array();
+        foreach ($messages as $message) {
+            if (null !== $limit && count($result) >= $limit) {
+                break;
+            }
+            if ($message->match($criterias)) {
+                $result[] = $message;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Request the API of Mailhog.
+     *
+     * @param string $method HTTP method to use (POST, PUT, GET, DELETE)
+     * @param string $path   relative path from '/api/v1/messages' (ex: null, '132')
+     * @param array  $parameters parameters to POST
+     *
+     * @return string response body
+     */
+    public function request($method, $path = null, $parameters = array())
+    {
+        if (null === $path) {
+            $url = '/api/v1/messages';
+        } else {
+            $url  = '/api/v1/messages/'.$path;
+        }
+
+        return json_decode($this->requestRaw($method, $url, $parameters), true);
+    }
+
+    /**
+     * Raw method to request the API of Mailhog.
+     *
+     * @param string $method     HTTP method
+     * @param string $url        absolute URL on server (`/api/v1/messages/132`)
+     * @param array  $parameters parameters to POST
+     *
+     * @return string response body
+     * @throws \RuntimeException
+     */
+    public function requestRaw($method, $url, $parameters = array())
+    {
+        $url = $this->url.$url;
+
+        if (false === $curl = curl_init()) {
+            throw new \RuntimeException('Unable to create a new cURL handle');
+        }
+
+        $options = array(
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER         => false,
+            CURLOPT_CUSTOMREQUEST  => $method,
+            CURLOPT_URL            => $url,
+            CURLOPT_TIMEOUT_MS     => 3000,
+            CURLOPT_TIMEOUT        => 3,
+            CURLOPT_FOLLOWLOCATION => 1,
+            CURLOPT_MAXREDIRS      => 5,
+            CURLOPT_FAILONERROR    => true,
+            CURLOPT_SSL_VERIFYPEER => false,
+        );
+
+        switch ($method) {
+            case 'HEAD':
+                $options[CURLOPT_NOBODY] = true;
+                break;
+
+            case 'GET':
+                $options[CURLOPT_HTTPGET] = true;
+                break;
+
+            case 'POST':
+            case 'PUT':
+            case 'DELETE':
+            case 'PATCH':
+                $options[CURLOPT_POSTFIELDS] = http_build_query($parameters);
+
+                break;
+        }
+
+        curl_setopt_array($curl, $options);
+
+        $result = curl_exec($curl);
+
+        $statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+
+        if ($statusCode === 200 || $statusCode === 204 || ($statusCode >= 300 && $statusCode <= 303)) {
+            return $result;
+        }
+
+        if (0 === $statusCode) {
+            throw new \RuntimeException(sprintf('Unable to connect to "%s".', $this->url));
+        }
+
+        throw new \RuntimeException(sprintf('Unexpected status code. Expected valid code, got %s.', $statusCode));
+    }
+}

--- a/MailhogMessage.php
+++ b/MailhogMessage.php
@@ -1,0 +1,407 @@
+<?php
+
+namespace Alex\MailCatcher;
+
+use Alex\MailCatcher\Mime\HeaderBag;
+use Alex\MailCatcher\Mime\Message as BaseMessage;
+
+/**
+ * Message in MailCatcher
+ *
+ * @author Alexandre Salomé <alexandre.salome@gmail.com>
+ * @author Christoph Gross <gross@gross-it.com>
+ */
+class MailhogMessage extends BaseMessage
+{
+    /**
+     * @var ClientMailhog
+     */
+    protected $client;
+
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var int
+     */
+    protected $size;
+
+    /**
+     * @var string
+     */
+    protected $subject;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var Person
+     */
+    protected $sender;
+
+    /**
+     * @var array array of Person
+     */
+    protected $recipients;
+
+    /**
+     * @var array array of Attachment
+     */
+    protected $attachments;
+
+    /**
+     * @var DateTime
+     */
+    protected $createdAt;
+
+    /**
+     * @var array
+     */
+    protected $formats;
+
+    /**
+     * Constructor
+     *
+     * @param Client $client
+     * @param array $data
+     */
+    public function __construct(MailhogClient $client, array $data = array())
+    {
+        $this->client = $client;
+        $this->loadFromArray($data);
+    }
+
+    /**
+     * @return Message
+     */
+    public function loadFromArray(array $array)
+    {
+        if (isset($array['ID'])) {
+            $this->id = $array['ID'];
+        }
+
+        if (isset($array['Created'])) {
+            // Looks like: 2016-10-09T21:38:24.065518968+02:00
+            // Make it ISO8601 compliant and drop the faction part of seconds: .065518968
+            $created = preg_replace('/\.\d+/', '', $array['Created']);
+            $this->createdAt = new \DateTime($created);
+        }
+
+        if (isset($array['Content'])) {
+            $content = $array['Content'];
+
+            if (isset($content['Size'])) {
+                $this->size = $content['Size'];
+            }
+
+            if (isset($content['Headers'])) {
+                $headers = $content['Headers'];
+
+                if (isset($headers['Subject'])) {
+                    $this->subject = $headers['Subject'][0];
+                }
+
+                if(isset($headers['From']) && isset($headers['From'][0])) {
+                    $this->sender = $this->createPersonFromEmailString($headers['From'][0]);
+                }
+
+                if(isset($headers['To']) && count($headers['To']) > 0) {
+                    $this->recipients = array_map(function ($string) {
+                        return $this->createPersonFromEmailString($string);
+                    }, $headers['To']);
+                }
+
+                if(isset($headers['Content-Type']) && count($headers['Content-Type']) > 0
+                    && preg_match('/(.*);/', $headers['Content-Type'][0], $match) === 1) {
+                    $this->type = $match[1];
+                }
+            }
+        }
+
+        if (isset($array['Raw'])) {
+            $raw = $array['Raw'];
+
+            if (isset($raw['Data'])) {
+                $this->loadSource($raw['Data']);
+            }
+        }
+
+        if (isset($array['MIME']) && isset($array['MIME']['Parts'])) {
+            $client = $this->client;
+            $filteredAttachments = array_filter($array['MIME']['Parts'], function($part) {
+                if (MailhogMessage::isAttachment($part))
+                    return true;
+                return false;
+            });
+            $this->attachments = array_map(function ($array, $key) use ($client) {
+                $array['id'] = $key;
+                return new MailhogAttachment($client, $array);
+            }, $filteredAttachments, array_keys($filteredAttachments));
+        }
+
+        return $this;
+    }
+
+    private static function isAttachment($part) {
+        // Does it have a Content Type?
+        if (isset($part['Headers']) && isset($part['Headers']['Content-Type'])) {
+            // Is it an attachment
+            if(isset($part['Headers']['Content-Disposition']) && count($part['Headers']['Content-Disposition']) > 0
+                && preg_match('/^attachment;/',$part['Headers']['Content-Disposition'][0]) === 1)
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * @param array $criterias
+     *
+     * @return bool
+     */
+    public function match(array $criterias)
+    {
+        foreach ($criterias as $type => $value) {
+            switch ($type) {
+                case 'from':
+                    if (!$this->getSender()->match($value)) {
+                        return false;
+                    }
+
+                    break;
+
+                case 'subject':
+                    if (false === strpos($this->getSubject(), $value)) {
+                        return false;
+                    }
+
+                    break;
+
+                case 'to':
+                    $foundTo = false;
+                    foreach ($this->getRecipients() as $recipient) {
+                        if ($recipient->match($value)) {
+                            $foundTo = true;
+                            break;
+                        }
+                    }
+
+                    if (!$foundTo) {
+                        return false;
+                    }
+
+                    break;
+
+                case 'contains':
+                    if (false === strpos($this->getContent(), $value)) {
+                        return false;
+                    }
+
+                    break;
+
+                case 'format':
+                    if (!$this->hasFormat($value)) {
+                        return false;
+                    }
+
+                    break;
+
+                case 'attachments':
+                    if (!is_bool($value)) {
+                        throw new \InvalidArgumentException(sprintf('Expected a boolean, got a "%s".', gettype($value)));
+                    }
+
+                    if ($value != $this->hasAttachments()) {
+                        return false;
+                    }
+
+                    break;
+
+                default:
+                    throw new \InvalidArgumentException(sprintf('Unexpected type of criteria: "%s".', $type));
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param $format
+     *
+     * @return bool
+     */
+    public function hasFormat($format)
+    {
+        return in_array($format, $this->getFormats());
+    }
+
+    /**
+     * @return array
+     */
+    public function getFormats()
+    {
+        throw new \RuntimeException('Not implemented for Mailhog');
+    }
+
+    /**
+     * @return integer
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getSize()
+    {
+        if (null === $this->size) {
+            $this->hydrate();
+        }
+
+        return $this->size;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSubject()
+    {
+        if (null === $this->subject) {
+            $this->hydrate();
+        }
+
+        return $this->subject;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isPlain()
+    {
+        return $this->getType() === 'text/plain';
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        if (null === $this->type) {
+            $this->hydrate();
+        }
+
+        return $this->type;
+    }
+
+    /**
+     * @return array array of Attachment
+     */
+    public function getAttachments()
+    {
+        if (null === $this->attachments) {
+            $this->hydrate();
+        }
+
+        return $this->attachments;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function hasAttachments()
+    {
+        return count($this->getAttachments()) > 0;
+    }
+
+    /**
+     * @return Person
+     */
+    public function getSender()
+    {
+        if (null === $this->sender) {
+            $this->hydrate();
+        }
+
+        return $this->sender;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRecipients()
+    {
+        if (null === $this->recipients) {
+            $this->hydrate();
+        }
+
+        return $this->recipients;
+    }
+
+    /**
+     * @return HeaderBag
+     */
+    public function getHeaders()
+    {
+        if (null === $this->headers) {
+            $this->hydrate();
+        }
+
+        return $this->headers;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContent()
+    {
+        if (null === $this->content) {
+            $this->hydrate();
+        }
+
+        return $this->content;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        if (null === $this->createdAt) {
+            $this->hydrate();
+        }
+
+        return $this->createdAt;
+    }
+
+    private function hydrate()
+    {
+        $this->loadFromArray($this->client->request('GET', $this->id));
+    }
+
+    /**
+     * @return string
+     */
+    public function delete()
+    {
+        return $this->client->request('DELETE', $this->id);
+    }
+
+    /**
+     * @return Person
+     */
+    private function createPersonFromEmailString($string) {
+        // Name <email@mail.tld>
+        if (preg_match('/^(?:(.+) )?<(.+)>$/', $string, $vars)) {
+            $name  = $vars[1] === '' ? null : $vars[1];
+            $email = $vars[2] === '' ? null : $vars[2];
+            return new Person($name, $email);
+        }
+        // email@mail.tld
+        return new Person('', $string);
+    }
+}

--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -3,15 +3,23 @@
 namespace Alex\MailCatcher\Tests;
 
 use Alex\MailCatcher\Client;
+use Alex\MailCatcher\MailhogClient;
 
 abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 {
+    public function isTestingMailhog() {
+        global $testMailhog;
+        return ($testMailhog === true);
+    }
+
     public function getClient()
     {
         if (!isset($_SERVER['MAILCATCHER_HTTP'])) {
             $this->markTestSkipped('mailcatcher HTTP missing');
         }
 
+        if ($this->isTestingMailhog())
+            return new MailhogClient($_SERVER['MAILHOG_HTTP']);
         return new Client($_SERVER['MAILCATCHER_HTTP']);
     }
 

--- a/Tests/BehatExtensionTest.php
+++ b/Tests/BehatExtensionTest.php
@@ -111,7 +111,8 @@ class BehatExtensionTest extends AbstractTest
                 'extensions' => array(
                         'Alex\MailCatcher\Behat\MailCatcherExtension\Extension' => array(
                             'url' => $failServer ? 'http://localhost:1337' : $client->getUrl(),
-                            'purge_before_scenario' => $purge_before_scenario
+                            'purge_before_scenario' => $purge_before_scenario,
+                            'mailhog' => $this->isTestingMailhog()
                     ),
                 )
             )

--- a/Tests/ClientTest.php
+++ b/Tests/ClientTest.php
@@ -34,7 +34,10 @@ class ClientTest extends AbstractTest
 
         // searchOne
         $message = $client->searchOne(array('subject' => '3 ='));
-        $this->assertInstanceOf('Alex\MailCatcher\Message', $message);
+        if ($this->isTestingMailhog())
+            $this->assertInstanceOf('Alex\MailCatcher\MailhogMessage', $message, "message exists");
+        else
+            $this->assertInstanceOf('Alex\MailCatcher\Message', $message, "message exists");
         $this->assertEquals('3 = 1 x 3 + 0', $message->getSubject());
 
         // search
@@ -63,7 +66,10 @@ class ClientTest extends AbstractTest
 
         $message = $client->searchOne();
 
-        $this->assertInstanceOf('Alex\MailCatcher\Message', $message, "message exists");
+        if ($this->isTestingMailhog())
+            $this->assertInstanceOf('Alex\MailCatcher\MailhogMessage', $message, "message exists");
+        else
+            $this->assertInstanceOf('Alex\MailCatcher\Message', $message, "message exists");
         $this->assertTrue($message->hasAttachments(), "message has attachments");
 
         $attachments = $message->getAttachments();

--- a/Tests/bootstrapMailhog.php
+++ b/Tests/bootstrapMailhog.php
@@ -1,0 +1,2 @@
+<?php
+$testMailhog = true;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
     <php>
         <server name="MAILCATCHER_HTTP" value="http://localhost:1080" />
         <server name="MAILCATCHER_SMTP" value="smtp://localhost:1025" />
+        <server name="MAILHOG_HTTP" value="http://localhost:8025" />
     </php>
 
     <filter>


### PR DESCRIPTION
This PR adds support for [Mailhog](https://github.com/mailhog/MailHog), a Mailcatcher clone written in Go. We recently switched because installing ruby and all theses gems required by Mailcatcher took to long in our VMs. We didn't want to touch our scenarios so I wrote this PR to add Mailhog support to this Behat extension.

**How to use it:**
Modify your `behat.yml` adapt the URL if needed and set the `mailhog`parameter to `true`:

```
default:
  suites:
    default:
      contexts:
        - MailCatcherContext
        - FeatureContext
      Alex\MailCatcher\Behat\MailCatcherExtension\Extension:
        url: http://localhost:8025
        purge_before_scenario: true
        mailhog: true
```

**Running tests:**
Testing Mailcatcher is still the same: 

```
./vendor/bin/phpunit --colors=always --debug -c phpunit.xml.dist
```

Testing Mailhog requires a bootstrap file: 

```
./vendor/bin/phpunit --colors=always --debug -c phpunit.xml.dist --bootstrap Tests/bootstrapMailhog.php
```

**How does it work?**
This PR hooks into the DI system used by Behat and checks for the `mailhog` parameter [here](https://github.com/cgrossde/mailcatcher/blob/feature-mailhog/Behat/MailCatcherExtension/Extension.php#L33) When mailhog is enabled the MailhogClient.php instead of Client.php is used to communicate with the Server. The MailhogClient uses it's own implementation of Message(MailhogMessage) and Attachment(MailhogAttachment) because the responses between a Mailhog and a Mailcatcher server differ. All other files are (mostly) untouched. 
