### PR TITLE
seeInMail($text): display content in the exception

### DIFF
--- a/Behat/MailCatcherContext.php
+++ b/Behat/MailCatcherContext.php
@@ -159,7 +159,7 @@ class MailCatcherContext implements Context, TranslatableContext, MailCatcherAwa
         }
 
         if (false === strpos($content, $text)) {
-            throw new \InvalidArgumentException(sprintf("Unable to find text \"%s\" in current message:\n%s", $text, $message->getContent()));
+            throw new \InvalidArgumentException(sprintf("Unable to find text \"%s\" in current message:\n%s", $text, $content));
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.0 (not released)
 
+- [bug] #28 - seeInMail($text): display content in the exception (Alexis Lefebvre)
 - [feature] #36 - Support for Symfony5 (Vincent Moulene)
 - [bug] #27 - Support for multipart with parameters (Nirbhay Patil)
 - [bug] Support for mailcatcher 1.7 (Alexandre Salomé)


### PR DESCRIPTION
In the method called by `I should see "…" in mail`, the text is searched with `strpos($content, $text)` but the error message display `$message->getContent()`.

This error was confusing when the email contained a `text/html` part because `$content` was equal to `$this->getCrawler($message)->text()` but the error message showed `$message->getContent()`.

So I changed this in order to display the same string that is used when searching for the expected string.