### PR TITLE
Add seeInMailSource($text)

### DIFF
--- a/Behat/MailCatcherContext.php
+++ b/Behat/MailCatcherContext.php
@@ -164,6 +164,20 @@ class MailCatcherContext implements Context, TranslatableContext, MailCatcherAwa
     }
 
     /**
+     * @Then /^I should see "([^"]+)" in mail source$/
+     */
+    public function seeInMailSource($text)
+    {
+        $message = $this->getCurrentMessage();
+
+        $content = $message->getContent();
+
+        if (false === strpos($content, $text)) {
+            throw new \InvalidArgumentException(sprintf("Unable to find text \"%s\" in current message source:\n%s", $text, $content));
+        }
+    }
+
+    /**
      * @Then /^(?P<count>\d+) mails? should be sent$/
      */
     public function verifyMailsSent($count)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Verify text presence in message:
 
 * Then I should see "**something**" in mail
 * Then I should see "**something else**" in mail
+* Then I should see "**something else**" in mail source
 
 Verify text presence in mail without opening:
 

--- a/Tests/BehatExtensionTest.php
+++ b/Tests/BehatExtensionTest.php
@@ -60,18 +60,22 @@ class BehatExtensionTest extends AbstractTest
             // Criteria "from"
             'When I open mail from "world@example.org"',
             'Then I should see "from world" in mail',
+            'Then I should see "from world" in mail source',
 
             // Criteria "to"
             'When I open mail to "mailcatcher@example.org"',
             'Then I should see "from world to mailcatcher" in mail',
+            'Then I should see "from world to mailcatcher" in mail source',
 
             // Criteria "containing"
             'When I open mail containing "to mailcatcher"',
             'Then I should see "from world to mailcatcher" in mail',
+            'Then I should see "from world to mailcatcher" in mail source',
 
             // Criteria "with subject"
             'When I open mail with subject "hello mailcatcher"',
             'Then I should see "from world to mailcatcher" in mail',
+            'Then I should see "from world to mailcatcher" in mail source',
         ));
 
         $this->runBehat(array(


### PR DESCRIPTION
I would like to perform a search in the email source, no matter if there is `text/html` or `text/plain` parts (as `seeInMail($text)` already do).

Use case: check that there is an image in an email. We can't use `Then I should see "something" in mail` since the test check only the text: https://github.com/alexandresalome/mailcatcher/blob/600c84163468b097025b197c312ac0814a436f4c/Behat/MailCatcherContext.php#L154