### PR TITLE
Add notSeeInMail() method

### DIFF
--- a/Behat/MailCatcherContext.php
+++ b/Behat/MailCatcherContext.php
@@ -140,11 +140,10 @@ class MailCatcherContext implements Context, TranslatableContext, MailCatcherAwa
         $message = $this->findMail(Message::CONTAINS_CRITERIA, $value);
     }
 
-
     /**
-     * @Then /^I should see "([^"]+)" in mail$/
+     * @return Message|null
      */
-    public function seeInMail($text)
+    public function getMessageContent()
     {
         $message = $this->getCurrentMessage();
 
@@ -158,8 +157,30 @@ class MailCatcherContext implements Context, TranslatableContext, MailCatcherAwa
             throw new \RuntimeException(sprintf('Unable to read mail'));
         }
 
+        return $content;
+    }
+
+    /**
+     * @Then /^I should see "([^"]+)" in mail$/
+     */
+    public function seeInMail($text)
+    {
+        $content = $this->getMessageContent();
+
         if (false === strpos($content, $text)) {
-            throw new \InvalidArgumentException(sprintf("Unable to find text \"%s\" in current message:\n%s", $text, $message->getContent()));
+            throw new \InvalidArgumentException(sprintf("Unable to find text \"%s\" in current message:\n%s", $text, $content));
+        }
+    }
+
+    /**
+     * @Then /^I should not see "([^"]+)" in mail$/
+     */
+    public function notSeeInMail($text)
+    {
+        $content = $this->getMessageContent();
+
+        if (false !== strpos($content, $text)) {
+            throw new \InvalidArgumentException(sprintf("Text \"%s\" was found in current message", $text));
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Verify text presence in message:
 * Then I should see "**something**" in mail
 * Then I should see "**something else**" in mail
 
+Verify text absence in message:
+
+* Then I should not see "**something**" in mail
+
 Verify text presence in mail without opening:
 
 * Then I should see mail from "**foo@example.org**"

--- a/Tests/BehatExtensionTest.php
+++ b/Tests/BehatExtensionTest.php
@@ -60,18 +60,22 @@ class BehatExtensionTest extends AbstractTest
             // Criteria "from"
             'When I open mail from "world@example.org"',
             'Then I should see "from world" in mail',
+            'Then I should not see "lorem" in mail',
 
             // Criteria "to"
             'When I open mail to "mailcatcher@example.org"',
             'Then I should see "from world to mailcatcher" in mail',
+            'Then I should not see "lorem" in mail',
 
             // Criteria "containing"
             'When I open mail containing "to mailcatcher"',
             'Then I should see "from world to mailcatcher" in mail',
+            'Then I should not see "lorem" in mail',
 
             // Criteria "with subject"
             'When I open mail with subject "hello mailcatcher"',
             'Then I should see "from world to mailcatcher" in mail',
+            'Then I should not see "lorem" in mail',
         ));
 
         $this->runBehat(array(


### PR DESCRIPTION
for `I should not see "([^"]+)" in mail`

Use case: we want to test that an email doesn't contain a given text, because there is a condition in the Twig file used to generate the text.