### PR TITLE
Parsing multipart more tolerant. Request plain and html format from M…

### DIFF
--- a/Message.php
+++ b/Message.php
@@ -70,6 +70,16 @@ class Message extends BaseMessage
     protected $formats;
 
     /**
+     * @var string
+     */
+    protected $plain;
+
+    /**
+     * @var string
+     */
+    protected $html;
+
+    /**
      * Constructor
      *
      * @param Client $client
@@ -362,6 +372,39 @@ class Message extends BaseMessage
     private function hydrate()
     {
         $this->loadFromArray($this->client->request('GET', $this->id.'.json'));
+    }
+
+    private function requestFormat($format)
+    {
+        if (!in_array($format, $this->getFormats())) {
+            throw new \InvalidArgumentException(sprintf("Format \"%s\" not available for message %d.", $format, $this->getId()));
+        }
+
+        return $this->client->request('GET', $this->id . ".$format", [], false);
+    }
+
+    /**
+     * @return string
+     */
+    public function getPlainFormat()
+    {
+        if (null === $this->plain) {
+            $this->plain = $this->requestFormat('plain');
+        }
+
+        return $this->plain;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHtmlFormat()
+    {
+        if (null === $this->html) {
+            $this->html = $this->requestFormat('html');
+        }
+
+        return $this->html;
     }
 
     /**

--- a/Mime/Part.php
+++ b/Mime/Part.php
@@ -127,7 +127,7 @@ class Part
             return;
         }
 
-        if (!preg_match('#^multipart/(alternative|mixed|related);.*boundary="?([^"]*)"?$#', $contentType, $vars)) {
+        if (!preg_match('#^multipart/(alternative|mixed|related);.*boundary="?([^"]*)"?.*$#', $contentType, $vars)) {
             throw new \InvalidArgumentException(sprintf('Unable to parse multipart header: "%s".', $contentType));
         }
 

--- a/README.md
+++ b/README.md
@@ -150,15 +150,17 @@ $message = $client->searchOne(array('subject' => 'Welcome'));
 ```php
 // Message API, get the content of a message
 $subject = $message->getSubject();
-$plainTextBody = $message->getPart('text/plain')->getContent();
-$htmlBody = $message->getPart('text/html')->getContent();
+$plainTextBody = $message->getPlainFormat(); // Mailcatcher is parsing; OR
+$plainTextBody = $message->getPart('text/plain')->getContent(); // this library parses
+$htmlBody = $message->getHtmlFormat(); // Mailcatcher is parsing; OR
+$htmlBody = $message->getPart('text/html')->getContent(); // this library parses
 
 // Message API, return a Person object or an array of Person object
-$person  = $message->getFrom();
+$person  = $message->getSender();
 $persons = $message->getRecipients();
 
 // Person API
-$person = $message->getFrom();
+$person = $message->getSender();
 
 $name = $person->getName(); // null means not provided
 $mail = $person->getMail();


### PR DESCRIPTION
…ailcatcher host. Readme typo.

I was testing an email created by PHPMailer and it contained

`Content-Type: multipart/related; boundary="b2_YaLOQIk96RaPsGlSFSSdp2OtVFPY0WPc1VUBzdWws"; type="text/html"`

the trailing `; type="text/html` did not match the regular expression used in the library.

Alternatively the __plain__ and __html__ formats can be retrived from Mailcatcher API, which seems to parse them properly. The API endpoints are `/messsages/{id}.plain` and `/messsages/{id}.html`. I added variables and methods for them. They however contain only the content, no headers.

In the Readme, method `getFrom()` should presumably be `getSender()`.